### PR TITLE
Simplified setting look and feel on non-Macs

### DIFF
--- a/src/beast/app/util/Utils.java
+++ b/src/beast/app/util/Utils.java
@@ -179,21 +179,16 @@ public class Utils {
 
             if (!lafLoaded) {
                 if (isMac()) {
-                    UIManager.setLookAndFeel("javax.swing.plaf.metal");
-                } else {
+                    UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+                } else if (isWindows()) {
+                    UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+                } else { // If Linux
                     try {
-                        for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-                            if ("Nimbus".equals(info.getName())) {
-                                UIManager.setLookAndFeel(info.getClassName());
-                                break;
-                            }
-                        }
+                        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
                     } catch (Exception e) {
-                        // If Nimbus is not available, you can set the GUI to another look and feel.
-                        UIManager.setLookAndFeel("javax.swing.plaf.metal");
+                        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
                     }
                 }
-                //UIManager.getSystemLookAndFeelClassName());
             }
         } catch (Exception e) {
         }


### PR DESCRIPTION
The Nimbus LaF has different class names in Java 6 vs Java 7/8. As BEAST is no longer compatible with Java 6, it's silly to cycle through all installed look and feels as it will always have the same name. It's also silly to fall back to Metal as Nimbus has been part of Java since version 6 update 10. On Linux the GTK LaF looks a lot prettier than Nimbus, so I've made GTK the default (as it is for BEAST1) with Nimbus the fall back. Finally, the actual look and feel class needs to be specified, not the package, so the UI manager statement for isMac would never do anything (it would be immediately caught).